### PR TITLE
OPENEUROPA-1101: Fix missing permission in provisioning.

### DIFF
--- a/src/TaskRunner/Commands/AuthorisationServiceCommands.php
+++ b/src/TaskRunner/Commands/AuthorisationServiceCommands.php
@@ -113,6 +113,7 @@ class AuthorisationServiceCommands extends AbstractCommands {
       'entitlements' => [
         'OeUser_SEARCH',
         'OeUser_READ',
+        'GROUP_SEARCH',
       ],
     ]);
 

--- a/src/TaskRunner/Commands/AuthorisationServiceCommands.php
+++ b/src/TaskRunner/Commands/AuthorisationServiceCommands.php
@@ -113,7 +113,7 @@ class AuthorisationServiceCommands extends AbstractCommands {
       'entitlements' => [
         'OeUser_SEARCH',
         'OeUser_READ',
-        'GROUP_SEARCH',
+        'GROUP_READ',
       ],
     ]);
 


### PR DESCRIPTION
## OPENEUROPA-1101

### Description

Fix missing permission in the provisioning command.

### Change log

- Added:
- Changed: Fix missing permission in the provisioning command.
- Deprecated:
- Removed:
- Fixed:
- Security:
