### PR TITLE
OPENEUROPA-1237: Improve oe_authorisation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "drush/drush": "^9",
         "openeuropa/code-review": "~1.0.0-alpha3@alpha",
         "openeuropa/drupal-core-require-dev": "8.6.x-dev",
-        "openeuropa/task-runner": "~1.0@alpha"
+        "openeuropa/task-runner": "~1.0-beta2"
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "drupal/devel": "^1.2",
         "drupal/drupal-extension": "^4.0.0@alpha",
         "drush/drush": "^9",
+        "nikic/php-parser": "~3.0",
         "openeuropa/code-review": "~1.0.0-alpha3@alpha",
         "openeuropa/drupal-core-require-dev": "8.6.x-dev",
         "openeuropa/task-runner": "~1.0-beta2"

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -11,3 +11,12 @@ parameters:
     - inc
     - theme
     - install
+
+  extra_tasks:
+    phpparser:
+      ignore_patterns: %tasks.phpcs.ignore_patterns%
+      visitors:
+        declare_strict_types: ~
+      triggered_by: %tasks.phpcs.triggered_by%
+  extensions:
+    - OpenEuropa\CodeReview\ExtraTasksExtension

--- a/modules/oe_authorisation_syncope/oe_authorisation_syncope.module
+++ b/modules/oe_authorisation_syncope/oe_authorisation_syncope.module
@@ -99,6 +99,9 @@ function oe_authorisation_syncope_form_user_form_alter(&$form, FormStateInterfac
     return;
   }
 
+  // Instead of simply resetting the cache and reloading the user, we make a
+  // new call to Syncope so that we know if something goes wrong with the
+  // request. If it does, we don't allow changes to this form.
   /** @var \Drupal\oe_authorisation_syncope\SyncopeRoleMapper $role_mapper */
   $role_mapper = \Drupal::service('oe_authorisation_syncope.role_mapper');
 

--- a/modules/oe_authorisation_syncope/src/Exception/SyncopeException.php
+++ b/modules/oe_authorisation_syncope/src/Exception/SyncopeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\oe_authorisation_syncope\Exception;
 
 /**

--- a/modules/oe_authorisation_syncope/src/Exception/SyncopeGroupException.php
+++ b/modules/oe_authorisation_syncope/src/Exception/SyncopeGroupException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\oe_authorisation_syncope\Exception;
 
 /**

--- a/modules/oe_authorisation_syncope/src/Exception/SyncopeGroupNotFoundException.php
+++ b/modules/oe_authorisation_syncope/src/Exception/SyncopeGroupNotFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\oe_authorisation_syncope\Exception;
 
 /**

--- a/modules/oe_authorisation_syncope/src/Exception/SyncopeLoginException.php
+++ b/modules/oe_authorisation_syncope/src/Exception/SyncopeLoginException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\oe_authorisation_syncope\Exception;
 
 /**

--- a/modules/oe_authorisation_syncope/src/Exception/SyncopeUserException.php
+++ b/modules/oe_authorisation_syncope/src/Exception/SyncopeUserException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\oe_authorisation_syncope\Exception;
 
 /**

--- a/modules/oe_authorisation_syncope/src/Exception/SyncopeUserNotFoundException.php
+++ b/modules/oe_authorisation_syncope/src/Exception/SyncopeUserNotFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\oe_authorisation_syncope\Exception;
 
 /**

--- a/modules/oe_authorisation_syncope/src/Syncope/SyncopeRealm.php
+++ b/modules/oe_authorisation_syncope/src/Syncope/SyncopeRealm.php
@@ -31,13 +31,6 @@ class SyncopeRealm {
   protected $path;
 
   /**
-   * Whether it's the root realm.
-   *
-   * @var bool
-   */
-  protected $isRoot;
-
-  /**
    * The UUID of the parent realm.
    *
    * @var string
@@ -62,7 +55,6 @@ class SyncopeRealm {
     $this->path = $path;
     $this->path = $path;
     $this->parent = $parent;
-    $this->isRoot = $parent == '/';
   }
 
   /**
@@ -112,7 +104,7 @@ class SyncopeRealm {
    *   TRUE if the realm has no parents or FALSE otherwise.
    */
   public function isRoot(): bool {
-    return $this->isRoot;
+    return $this->parent == '/';
   }
 
 }

--- a/modules/oe_authorisation_syncope/src/Syncope/SyncopeRealm.php
+++ b/modules/oe_authorisation_syncope/src/Syncope/SyncopeRealm.php
@@ -53,7 +53,6 @@ class SyncopeRealm {
     $this->uuid = $uuid;
     $this->name = $name;
     $this->path = $path;
-    $this->path = $path;
     $this->parent = $parent;
   }
 

--- a/modules/oe_authorisation_syncope/src/Syncope/SyncopeUser.php
+++ b/modules/oe_authorisation_syncope/src/Syncope/SyncopeUser.php
@@ -110,11 +110,7 @@ class SyncopeUser {
    *   Whether the user is root level.
    */
   public function isRootUser(): bool {
-    if (strpos($this->getName(), '@') === FALSE) {
-      return TRUE;
-    }
-
-    return FALSE;
+    return (strpos($this->getName(), '@') === FALSE);
   }
 
 }

--- a/modules/oe_authorisation_syncope/src/SyncopeClient.php
+++ b/modules/oe_authorisation_syncope/src/SyncopeClient.php
@@ -256,6 +256,7 @@ class SyncopeClient {
     }
 
     $drupal_name = str_replace('@' . $this->siteRealm, '', $response->name);
+
     return new SyncopeGroup($response->key, $response->name, $drupal_name);
   }
 

--- a/modules/oe_authorisation_syncope/src/SyncopeClient.php
+++ b/modules/oe_authorisation_syncope/src/SyncopeClient.php
@@ -21,6 +21,8 @@ use OpenEuropa\SyncopePhpClient\Api\AnyObjectsApi;
 use OpenEuropa\SyncopePhpClient\Api\GroupsApi;
 use OpenEuropa\SyncopePhpClient\Api\RealmsApi;
 use OpenEuropa\SyncopePhpClient\Configuration;
+use OpenEuropa\SyncopePhpClient\Model\AnyObjectTO;
+use OpenEuropa\SyncopePhpClient\Model\GroupTO;
 
 /**
  * Service that wraps the Syncope PHP client.
@@ -209,13 +211,13 @@ class SyncopeClient {
 
     $group_name = "$name@$realm";
 
-    $payload = new \stdClass();
-    $payload->{'@class'} = 'org.apache.syncope.common.lib.to.GroupTO';
-    $payload->realm = '/' . $this->siteRealm;
-    $payload->name = $group_name;
-
+    $groupTo = new GroupTO([
+      'realm' => '/' . $this->siteRealm,
+      'name' => $group_name,
+    ]);
+    $groupTo->setClass('org.apache.syncope.common.lib.to.GroupTO');
     try {
-      $response = $api->createGroup($this->syncopeDomain, $payload);
+      $response = $api->createGroup($this->syncopeDomain, $groupTo);
     }
     catch (\Exception $e) {
       $this->logger->error(sprintf('There was a problem creating the group %s: %s.', $group_name, $e->getMessage()));
@@ -327,22 +329,23 @@ class SyncopeClient {
       $realm = '/';
     }
 
-    $payload = new \stdClass();
-    $payload->{'@class'} = 'org.apache.syncope.common.lib.to.AnyObjectTO';
-    $payload->realm = $realm;
-    $payload->memberships = $memberships;
-    $payload->name = $username;
-    $payload->type = 'OeUser';
-    // @todo move this out of here and set the EULogin ID dynamically.
-    $payload->plainAttrs = [
-      [
-        'schema' => 'eulogin_id',
-        'values' => [$user->getName()],
+    $anyObjectTo = new AnyObjectTO([
+      'realm' => $realm,
+      'memberships' => $memberships,
+      'name' => $username,
+      'type' => 'OeUser',
+      // @todo move this out of here and set the EULogin ID dynamically.
+      'plainAttrs' => [
+        [
+          'schema' => 'eulogin_id',
+          'values' => [$user->getName()],
+        ],
       ],
-    ];
+    ]);
+    $anyObjectTo->setClass('org.apache.syncope.common.lib.to.AnyObjectTO');
 
     try {
-      $response = $api->createAnyObject($this->syncopeDomain, $payload);
+      $response = $api->createAnyObject($this->syncopeDomain, $anyObjectTo);
     }
     catch (\Exception $e) {
       $this->logger->error(sprintf('There was a problem creating the user %s: %s.', $user->getName(), $e->getMessage()));
@@ -394,23 +397,25 @@ class SyncopeClient {
     }
 
     $username = $user->getName() . '@' . $this->siteRealm;
-    $payload = new \stdClass();
-    $payload->{'@class'} = 'org.apache.syncope.common.lib.to.AnyObjectTO';
-    $payload->realm = '/' . $this->siteRealm;
-    $payload->memberships = $memberships;
-    $payload->name = $username;
-    $payload->type = 'OeUser';
-    $payload->key = $user->getUuid();
-    // @todo move this out of here and set the EULogin ID dynamically.
-    $payload->plainAttrs = [
-      [
-        'schema' => 'eulogin_id',
-        'values' => [$user->getName()],
+
+    $anyObjectTo = new AnyObjectTO([
+      'realm' => '/' . $this->siteRealm,
+      'memberships' => $memberships,
+      'name' => $username,
+      'type' => 'OeUser',
+      'key' => $user->getUuid(),
+      // @todo move this out of here and set the EULogin ID dynamically.
+      'plainAttrs' => [
+        [
+          'schema' => 'eulogin_id',
+          'values' => [$user->getName()],
+        ],
       ],
-    ];
+    ]);
+    $anyObjectTo->setClass('org.apache.syncope.common.lib.to.AnyObjectTO');
 
     try {
-      $response = $api->updateAnyObject($user->getUuid(), $this->syncopeDomain, $payload);
+      $response = $api->updateAnyObject($user->getUuid(), $this->syncopeDomain, $anyObjectTo);
     }
     catch (\Exception $e) {
       $this->logger->error(sprintf('There was a problem updating the user %s: %s.', $user->getName(), $e->getMessage()));
@@ -630,23 +635,24 @@ class SyncopeClient {
       ];
     }
 
-    $payload = new \stdClass();
-    $payload->{'@class'} = 'org.apache.syncope.common.lib.to.AnyObjectTO';
-    $payload->realm = '/';
-    $payload->memberships = $memberships;
-    $payload->name = $root_user->getName();
-    $payload->type = 'OeUser';
-    $payload->key = $root_user->getUuid();
-    // @todo move this out of here and set the EULogin ID dynamically.
-    $payload->plainAttrs = [
-      [
-        'schema' => 'eulogin_id',
-        'values' => [$root_user->getName()],
+    $anyObjectTo = new AnyObjectTO([
+      'realm' => '/',
+      'memberships' => $memberships,
+      'name' => $root_user->getName(),
+      'type' => 'OeUser',
+      'key' => $root_user->getUuid(),
+      // @todo move this out of here and set the EULogin ID dynamically.
+      'plainAttrs' => [
+        [
+          'schema' => 'eulogin_id',
+          'values' => [$root_user->getName()],
+        ],
       ],
-    ];
+    ]);
+    $anyObjectTo->setClass('org.apache.syncope.common.lib.to.AnyObjectTO');
 
     try {
-      $response = $api->updateAnyObject($root_user->getUuid(), $this->syncopeDomain, $payload);
+      $response = $api->updateAnyObject($root_user->getUuid(), $this->syncopeDomain, $anyObjectTo);
     }
     catch (\Exception $e) {
       $this->logger->error(sprintf('There was a problem updating the user %s: %s.', $user->getName(), $e->getMessage()));

--- a/modules/oe_authorisation_syncope/src/SyncopeClient.php
+++ b/modules/oe_authorisation_syncope/src/SyncopeClient.php
@@ -619,7 +619,6 @@ class SyncopeClient {
       throw new SyncopeUserException('The root user is missing. We cannot add a global role.');
     }
 
-    // @todo check if the role is set already.
     $api = new AnyObjectsApi($this->client, $this->configuration);
 
     $memberships = [];

--- a/modules/oe_authorisation_syncope/src/SyncopeClient.php
+++ b/modules/oe_authorisation_syncope/src/SyncopeClient.php
@@ -32,19 +32,14 @@ use OpenEuropa\SyncopePhpClient\Model\GroupTO;
 class SyncopeClient {
 
   /**
-   * The identifier to use for retrieving a user by UUID.
+   * The identifier to use for retrieving Syncope objects by UUID.
    */
-  const USER_IDENTIFIER_UUID = 'uuid';
+  const IDENTIFIER_UUID = 'uuid';
 
   /**
    * The identifier to use for retrieving a user by username.
    */
   const USER_IDENTIFIER_USERNAME = 'username';
-
-  /**
-   * The identifier to use for retrieving a group by UUID.
-   */
-  const GROUP_IDENTIFIER_UUID = 'uuid';
 
   /**
    * The identifier to use for retrieving a group by name.
@@ -248,7 +243,7 @@ class SyncopeClient {
    * @throws \Drupal\oe_authorisation_syncope\Exception\SyncopeGroupException
    * @throws \Drupal\oe_authorisation_syncope\Exception\SyncopeGroupNotFoundException
    */
-  public function getGroup(string $identifier, $identifier_type = self::GROUP_IDENTIFIER_UUID): SyncopeGroup {
+  public function getGroup(string $identifier, $identifier_type = self::IDENTIFIER_UUID): SyncopeGroup {
     $api = new GroupsApi($this->client, $this->configuration);
     if ($identifier_type === self::GROUP_IDENTIFIER_NAME) {
       $identifier .= '@' . $this->siteRealm;
@@ -454,7 +449,7 @@ class SyncopeClient {
    * @throws \Drupal\oe_authorisation_syncope\Exception\SyncopeUserException
    * @throws \Drupal\oe_authorisation_syncope\Exception\SyncopeUserNotFoundException
    */
-  public function getUser(string $identifier, $identifier_type = self::USER_IDENTIFIER_UUID): SyncopeUser {
+  public function getUser(string $identifier, $identifier_type = self::IDENTIFIER_UUID): SyncopeUser {
     $api = new AnyObjectsApi($this->client, $this->configuration);
     if ($identifier_type === self::USER_IDENTIFIER_USERNAME) {
       $identifier .= '@' . $this->siteRealm;

--- a/modules/oe_authorisation_syncope/src/SyncopeRoleMapper.php
+++ b/modules/oe_authorisation_syncope/src/SyncopeRoleMapper.php
@@ -81,7 +81,7 @@ class SyncopeRoleMapper {
     }
 
     // We also don't want to ever map the default roles.
-    if (in_array($role->id(), ['anonymous', 'authenticated'])) {
+    if (\in_array($role->id(), ['anonymous', 'authenticated'])) {
       return;
     }
 
@@ -148,6 +148,8 @@ class SyncopeRoleMapper {
    *
    * @return array
    *   The Drupal roles of this user mapped from Syncope.
+   *
+   * @throws \Drupal\oe_authorisation_syncope\Exception\SyncopeUserException
    */
   public function getUserDrupalRolesFromSyncope(UserInterface $user): array {
     $uuid = $user->get('syncope_uuid')->value;
@@ -217,6 +219,7 @@ class SyncopeRoleMapper {
         $this->setRoleUuid($role, $group->getUuid());
         return;
       }
+
       // If the ID is NULL, we try by name. Normally this should not be needed
       // but just in case the role already exists on the Syncope instance.
       $group = $this->client->getGroup($role->id(), SyncopeClient::IDENTIFIER_NAME);
@@ -238,7 +241,7 @@ class SyncopeRoleMapper {
    * @param \Drupal\user\RoleInterface $role
    *   The Drupal role.
    */
-  protected function mapExistingRole(RoleInterface $role) {
+  protected function mapExistingRole(RoleInterface $role): void {
     // We can just defer to mapNewRole() as it does the check for existing role.
     $this->mapNewRole($role);
   }

--- a/modules/oe_authorisation_syncope/src/SyncopeRoleMapper.php
+++ b/modules/oe_authorisation_syncope/src/SyncopeRoleMapper.php
@@ -219,7 +219,7 @@ class SyncopeRoleMapper {
       }
       // If the ID is NULL, we try by name. Normally this should not be needed
       // but just in case the role already exists on the Syncope instance.
-      $group = $this->client->getGroup($role->id(), SyncopeClient::GROUP_IDENTIFIER_NAME);
+      $group = $this->client->getGroup($role->id(), SyncopeClient::IDENTIFIER_NAME);
       // Just in case the group is already there but no UUID has been set.
       $this->setRoleUuid($role, $group->getUuid());
     }

--- a/modules/oe_authorisation_syncope/src/SyncopeUserMapper.php
+++ b/modules/oe_authorisation_syncope/src/SyncopeUserMapper.php
@@ -92,14 +92,21 @@ class SyncopeUserMapper {
   public function preDelete(UserInterface $user): void {
     $uuid = $user->get('syncope_uuid')->value;
     if (!$uuid) {
-      // We do nothing here, not even log.
+      // We do nothing here, not even log because users without a UUID should
+      // not have to be deleted.
       return;
     }
 
-    $syncopeUser = $this->client->getUser($uuid);
-    if (empty($syncopeUser)) {
+    try {
+      $this->client->getUser($uuid);
+    }
+    catch (SyncopeUserNotFoundException $exception) {
+      // If the user is not found, we do nothing. It means the user was deleted
+      // in Syncope so we can allow the deletion here.
       return;
     }
+
+    // If any other exceptions are thrown, we block the user delete in Drupal.
     $this->client->deleteUser($uuid);
   }
 
@@ -178,7 +185,7 @@ class SyncopeUserMapper {
     }
 
     try {
-      $syncope_user = $this->client->getUser($user->label(), SyncopeClient::USER_IDENTIFIER_USERNAME);
+      $syncope_user = $this->client->getUser($user->label(), SyncopeClient::IDENTIFIER_NAME);
     }
     catch (SyncopeUserNotFoundException $e) {
       $roles = $this->roleMapper->getRolesForUser($user);

--- a/modules/oe_authorisation_syncope/src/SyncopeUserMapper.php
+++ b/modules/oe_authorisation_syncope/src/SyncopeUserMapper.php
@@ -96,7 +96,10 @@ class SyncopeUserMapper {
       return;
     }
 
-    // @todo, see if there is a user to delete.
+    $syncopeUser = $this->client->getUser($uuid);
+    if (empty($syncopeUser)) {
+      return;
+    }
     $this->client->deleteUser($uuid);
   }
 

--- a/modules/oe_authorisation_syncope/tests/src/Kernel/SyncopeRoleTest.php
+++ b/modules/oe_authorisation_syncope/tests/src/Kernel/SyncopeRoleTest.php
@@ -32,7 +32,7 @@ class SyncopeRoleTest extends SyncopeTestBase {
     $this->assertInstanceOf(SyncopeGroup::class, $group);
 
     // Check in Syncope we have the role by machine name.
-    $group = $this->getClient()->getGroup($role->id(), SyncopeClient::GROUP_IDENTIFIER_NAME);
+    $group = $this->getClient()->getGroup($role->id(), SyncopeClient::IDENTIFIER_NAME);
     $this->assertInstanceOf(SyncopeGroup::class, $group);
 
     // Delete the role and make sure it's gone in Syncope.
@@ -58,7 +58,7 @@ class SyncopeRoleTest extends SyncopeTestBase {
 
     // Assert no role got created.
     try {
-      $this->getClient()->getGroup($role->id(), SyncopeClient::GROUP_IDENTIFIER_NAME);
+      $this->getClient()->getGroup($role->id(), SyncopeClient::IDENTIFIER_NAME);
       $this->fail('The group was found and should not be');
     }
     catch (\Exception $exception) {

--- a/modules/oe_authorisation_syncope/tests/src/Kernel/SyncopeRoleTest.php
+++ b/modules/oe_authorisation_syncope/tests/src/Kernel/SyncopeRoleTest.php
@@ -37,6 +37,8 @@ class SyncopeRoleTest extends SyncopeTestBase {
 
     // Delete the role and make sure it's gone in Syncope.
     $role->delete();
+
+    // Check if the group was deleted correctly.
     try {
       $this->getClient()->getGroup($uuid);
       $this->fail('The group was found and should not be');

--- a/modules/oe_authorisation_syncope/tests/src/Kernel/SyncopeTestBase.php
+++ b/modules/oe_authorisation_syncope/tests/src/Kernel/SyncopeTestBase.php
@@ -38,11 +38,11 @@ class SyncopeTestBase extends KernelTestBase {
    */
   protected function setUp(): void {
     $GLOBALS['config']['oe_authorisation_syncope.settings']['credentials'] = [
-      'username' => 'admin',
-      'password' => 'password',
+      'username' => $_ENV['SYNCOPE_USER'],
+      'password' => $_ENV['SYNCOPE_PASSWORD'],
     ];
-    $GLOBALS['config']['oe_authorisation_syncope.settings']['endpoint'] = 'http://syncope:8080/syncope/rest';
-    $GLOBALS['config']['oe_authorisation_syncope.settings']['site_realm_name'] = 'sitea';
+    $GLOBALS['config']['oe_authorisation_syncope.settings']['endpoint'] = $_ENV['SYNCOPE_ENDPOINT'];
+    $GLOBALS['config']['oe_authorisation_syncope.settings']['site_realm_name'] = $_ENV['SYNCOPE_REALM_NAME'];
 
     parent::setUp();
 

--- a/modules/oe_authorisation_syncope/tests/src/Kernel/SyncopeUserTest.php
+++ b/modules/oe_authorisation_syncope/tests/src/Kernel/SyncopeUserTest.php
@@ -46,12 +46,13 @@ class SyncopeUserTest extends SyncopeTestBase {
 
     // Delete the user.
     $user->delete();
-    // Assert the user has been deleted.
+
+    // Assert the user has been deleted in Syncope.
     try {
-      $syncope_user = $this->getClient()->getUser($uuid);
+      $this->getClient()->getUser($uuid);
     }
     catch (SyncopeUserNotFoundException $exception) {
-      $this->assertEquals("The user was not found.", $exception->getMessage());
+      $this->assertInstanceOf(SyncopeUserNotFoundException::class, $exception);
     }
   }
 

--- a/modules/oe_authorisation_syncope/tests/src/Kernel/SyncopeUserTest.php
+++ b/modules/oe_authorisation_syncope/tests/src/Kernel/SyncopeUserTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_authorisation_syncope\Kernel;
 
+use Drupal\oe_authorisation_syncope\Exception\SyncopeUserNotFoundException;
 use Drupal\oe_authorisation_syncope\Syncope\SyncopeUser;
 use Drupal\user\UserInterface;
 
@@ -45,7 +46,13 @@ class SyncopeUserTest extends SyncopeTestBase {
 
     // Delete the user.
     $user->delete();
-    // @todo assert the user got deleted.
+    // Assert the user has been deleted.
+    try {
+      $syncope_user = $this->getClient()->getUser($uuid);
+    }
+    catch (SyncopeUserNotFoundException $exception) {
+      $this->assertEquals("The user was not found.", $exception->getMessage());
+    }
   }
 
   /**

--- a/modules/oe_authorisation_syncope/tests/src/Kernel/SyncopeUserTest.php
+++ b/modules/oe_authorisation_syncope/tests/src/Kernel/SyncopeUserTest.php
@@ -24,6 +24,7 @@ class SyncopeUserTest extends SyncopeTestBase {
     // Assert we have the user in Syncope.
     $uuid = $user->get('syncope_uuid')->value;
     $this->assertNotEmpty($uuid);
+
     $syncope_user = $this->getClient()->getUser($uuid);
     $this->assertInstanceOf(SyncopeUser::class, $syncope_user);
     $this->assertEquals('Kevin@sitea', $syncope_user->getName());
@@ -38,8 +39,10 @@ class SyncopeUserTest extends SyncopeTestBase {
     $syncope_user = $this->getClient()->getUser($uuid);
     $this->assertInstanceOf(SyncopeUser::class, $syncope_user);
     $this->assertEquals('Mark@sitea', $syncope_user->getName());
+
     $groups = $syncope_user->getGroups();
     $this->assertCount(1, $groups);
+
     $group_uuid = reset($groups);
     $group = $this->getClient()->getGroup($group_uuid);
     $this->assertEquals('site_manager', $group->getDrupalName());
@@ -129,6 +132,7 @@ class SyncopeUserTest extends SyncopeTestBase {
       ->create(['name' => $name]);
 
     $user->save();
+
     return $user;
   }
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,10 @@
   <php>
     <ini name="error_reporting" value="32767"/>
     <ini name="memory_limit" value="-1"/>
+    <env name="SYNCOPE_USER" value="${authorisation.server.username}"/>
+    <env name="SYNCOPE_PASSWORD" value="${authorisation.server.password}"/>
+    <env name="SYNCOPE_ENDPOINT" value="${authorisation.server.endpoint}"/>
+    <env name="SYNCOPE_REALM_NAME" value="${authorisation.server.site_realm_name}"/>
     <env name="SIMPLETEST_IGNORE_DIRECTORIES" value="${drupal.root}"/>
     <env name="SIMPLETEST_BASE_URL" value="${drupal.base_url}"/>
     <env name="SIMPLETEST_DB" value="mysql://${drupal.database.user}:${drupal.database.password}@${drupal.database.host}:${drupal.database.port}/${drupal.database.name}"/>

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -30,7 +30,7 @@ drupal:
     config:
       oe_authorisation_syncope.settings:
         credentials:
-          username: 'admin'
+          username: 'system-account-sitea'
           password: 'password'
         endpoint: 'http://syncope:8080/syncope/rest'
         domain: 'Master'

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -41,6 +41,7 @@ authorisation:
     username: "admin"
     password: "password"
     endpoint: "http://syncope:8080/syncope/rest"
+    site_realm_name: 'sitea'
 
 commands:
   drupal:site-setup:

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -30,7 +30,7 @@ drupal:
     config:
       oe_authorisation_syncope.settings:
         credentials:
-          username: 'system-account-sitea'
+          username: 'admin'
           password: 'password'
         endpoint: 'http://syncope:8080/syncope/rest'
         domain: 'Master'

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -101,4 +101,19 @@ class FeatureContext extends DrupalContext {
     }
   }
 
+  /**
+   * Asserts that the given role checkbox is disabled.
+   *
+   * @Given I am at the :user user page
+   * @When I visit the :user user page
+   */
+  public function iVisitUsersPage(string $name): void {
+    $user_storage = \Drupal::entityTypeManager()->getStorage('user');
+    $user_storage->resetCache();
+    $users = $user_storage->loadByProperties(['name' => $name]);
+    /** @var \Drupal\user\UserInterface $user */
+    $user = reset($users);
+    $this->getSession()->visit($this->locatePath($user->toUrl()->getInternalPath()));
+  }
+
 }

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -58,6 +58,8 @@ class FeatureContext extends DrupalContext {
    *   The role.
    * @param bool $has
    *   Whether to check if the user has or does not have those roles.
+   *
+   * @throws \Exception
    */
   protected function assertUserRole(string $name, string $role, bool $has): void {
     $user_storage = \Drupal::entityTypeManager()->getStorage('user');
@@ -88,6 +90,8 @@ class FeatureContext extends DrupalContext {
    * Asserts that the given role checkbox is disabled.
    *
    * @Then the :name role checkbox should be disabled
+   *
+   * @throws \Exception
    */
   public function assertRoleCheckboxDisabled(string $name): void {
     $session = $this->getSession();

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -89,7 +89,7 @@ class FeatureContext extends DrupalContext {
    *
    * @Then the :name role checkbox should be disabled
    */
-  public function theRoleCheckboxShouldBeDisabled(string $name): void {
+  public function assertRoleCheckboxDisabled(string $name): void {
     $session = $this->getSession();
     $element = $session->getPage()->findField($name);
     if (!$element instanceof NodeElement) {
@@ -99,21 +99,6 @@ class FeatureContext extends DrupalContext {
     if ($element->getAttribute('disabled') !== 'disabled') {
       throw new \Exception(sprintf('%s role checkbox is not disabled.', $name));
     }
-  }
-
-  /**
-   * Asserts that the given role checkbox is disabled.
-   *
-   * @Given I am at the :user user page
-   * @When I visit the :user user page
-   */
-  public function iVisitUsersPage(string $name): void {
-    $user_storage = \Drupal::entityTypeManager()->getStorage('user');
-    $user_storage->resetCache();
-    $users = $user_storage->loadByProperties(['name' => $name]);
-    /** @var \Drupal\user\UserInterface $user */
-    $user = reset($users);
-    $this->getSession()->visit($this->locatePath($user->toUrl()->getInternalPath()));
   }
 
 }

--- a/tests/Behat/SyncopeContext.php
+++ b/tests/Behat/SyncopeContext.php
@@ -183,8 +183,7 @@ class SyncopeContext extends RawDrupalContext {
       $syncope_users = $this->getSyncopeClient()->getAllUsers($user->label());
       $root_user = NULL;
       foreach ($syncope_users as $syncope_user) {
-        // @todo refactor this to determine root user inside the SyncopeUser.
-        if (strpos($syncope_user->getName(), '@') === FALSE) {
+        if ($syncope_user->isRootUser()) {
           $root_user = $syncope_user;
           break;
         }

--- a/tests/Behat/SyncopeContext.php
+++ b/tests/Behat/SyncopeContext.php
@@ -265,6 +265,8 @@ class SyncopeContext extends RawDrupalContext {
   /**
    * Asserts that a role exists in Syncope.
    *
+   * @throws \Exception
+   *
    * @Then the role :role should exist in Syncope
    */
   public function assertRoleExistsInSyncope(string $role): void {
@@ -286,6 +288,8 @@ class SyncopeContext extends RawDrupalContext {
    *   The user roles.
    * @param bool $has
    *   Whether to check if the user has or does not have those roles.
+   *
+   * @throws \Exception
    */
   protected function assertUserRolesInSyncope(string $name, string $roles, bool $has): void {
     $user = $this->loadUserByName($name);
@@ -321,6 +325,8 @@ class SyncopeContext extends RawDrupalContext {
    * @param \Behat\Behat\Hook\Scope\AfterScenarioScope $afterScenarioScope
    *   The scope.
    *
+   * @throws \Exception
+   *
    * @AfterScenario
    */
   public function cleanUpSyncopeUsers(AfterScenarioScope $afterScenarioScope): void {
@@ -337,6 +343,8 @@ class SyncopeContext extends RawDrupalContext {
    *
    * @return \Drupal\user\UserInterface
    *   The entity.
+   *
+   * @throws \Exception
    */
   protected function loadUserByName(string $name): UserInterface {
     $users = $this->getEntityTypeManager()->getStorage('user')->loadByProperties(['name' => $name]);
@@ -356,6 +364,8 @@ class SyncopeContext extends RawDrupalContext {
    *
    * @return \Drupal\user\RoleInterface
    *   The entity.
+   *
+   * @throws \Exception
    */
   protected function loadRoleByName(string $role): RoleInterface {
     $roles = $this->getEntityTypeManager()->getStorage('user_role')->loadByProperties(['label' => [$role]]);
@@ -376,6 +386,8 @@ class SyncopeContext extends RawDrupalContext {
    *
    * @return \Drupal\user\RoleInterface[]
    *   The entities.
+   *
+   * @throws \Exception
    */
   protected function loadRolesByCommaSeparatedNames(string $roles): array {
     $roles = explode(', ', $roles);

--- a/tests/features/syncope.feature
+++ b/tests/features/syncope.feature
@@ -60,3 +60,13 @@ Feature: Syncope integration
     And I go to "/user"
     And I click "Edit"
     Then the "Support Engineer" role checkbox should be disabled
+
+  Scenario: Users should get their roles from Syncope on load
+    Given I am logged in as a user with the 'Site Manager' role
+    And users:
+      | name | mail             |
+      | Kevin | Kevin@example.com |
+    And the user "Kevin" does not have the role "Site Manager" in Drupal
+    And the user "Kevin" gets the role "Site Manager" in Syncope
+    And I visit the "Kevin" user page
+    Then the user "Kevin" should have the role "Site Manager" in Drupal

--- a/tests/features/syncope.feature
+++ b/tests/features/syncope.feature
@@ -6,7 +6,7 @@ Feature: Syncope integration
 
   Scenario Outline: Users should get their roles from Syncope on login
     Given users:
-      | name | mail             |
+      | name  | mail              |
       | Kevin | Kevin@example.com |
     And the user "Kevin" does not have the role "<role>" in Drupal
     And the user "Kevin" gets the role "<role>" in Syncope
@@ -22,7 +22,7 @@ Feature: Syncope integration
 
   Scenario Outline: Users should lose their roles in Drupal on login if they no longer have them assigned in Syncope
     Given users:
-      | name | mail             |
+      | name  | mail              |
       | Kevin | Kevin@example.com |
     And the user "Kevin" has the roles "Site Manager, Support Engineer" in Drupal
     And the user "Kevin" loses the role "<lost>" in Syncope
@@ -39,13 +39,13 @@ Feature: Syncope integration
 
   Scenario: Users created in Drupal should be mapped in Syncope with the correct roles
     Given users:
-      | name | mail             | roles                |
+      | name  | mail              | roles                |
       | Kevin | Kevin@example.com | Editor, Site Manager |
     Then the user "Kevin" should have the roles "Editor, Site Manager" in Syncope
 
   Scenario: Users updated in Drupal should be mapped in Syncope with the correct roles
     Given users:
-      | name | mail             | roles                |
+      | name  | mail              | roles                |
       | Kevin | Kevin@example.com | Editor, Site Manager |
     And I am logged in as a user with the "administer users, administer permissions" permissions
     And I go to "/admin/people"
@@ -61,12 +61,12 @@ Feature: Syncope integration
     And I click "Edit"
     Then the "Support Engineer" role checkbox should be disabled
 
-  Scenario: Users should get their roles from Syncope on load
-    Given I am logged in as a user with the 'Site Manager' role
+  Scenario: The user edit form should reflect the roles found in Syncope for that user
+    Given I am logged in as a user with the "administer users, administer permissions" permissions
     And users:
-      | name | mail             |
+      | name  | mail              |
       | Kevin | Kevin@example.com |
-    And the user "Kevin" does not have the role "Site Manager" in Drupal
     And the user "Kevin" gets the role "Site Manager" in Syncope
-    And I visit the "Kevin" user page
-    Then the user "Kevin" should have the role "Site Manager" in Drupal
+    And I go to "/admin/people"
+    And I click "Edit" in the "Kevin" row
+    Then the "Site Manager" checkbox should be checked


### PR DESCRIPTION
## OPENEUROPA-1237

### Description

- [x] Handle all todos as needed/appropriate and that can be done. The setting of the EULogin ID dynamically is still not possible and should be left out. 
- [ ] Use the provisioned site system user in the API instead of the admin/password
- [x] Inside SyncopeRealm, determine dynamically if it's a root realm and kill the isRoot variable 
- [x] Use the library model classes instead of the "payload" stdclass objects 
- [x] Refactor code duplication in the SyncopeClient in the create and update methods as possible 
- [x] Use "openeuropa/code-review": "~1.0@alpha", 
- [x] In the Kernel test, pass the global variables from the phpunit.xml file (and hydrate those via the runner) and make use of them in the test
- [x] Fix typo in "Scenario Outline: Users should loses their roles in Drupal on"
- [x] Refactor the naming of the "USER_IDENTIFIER_UUID" & co constants
- [x] Behat test that checks that the user edit form shows the roles refreshed from syncope on load.


