### PR TITLE
OPENEUROPA-1609 Fix behat.yml.dist to use drupal-extension properly.

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -27,7 +27,7 @@ default:
               site status: 'admin/reports/status'
               user account: 'user'
   extensions:
-    Behat\MinkExtension:
+    Drupal\MinkExtension:
       goutte: ~
       selenium2: ~
       javascript_session: selenium2

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/config_devel": "~1.2",
         "drupal/console": "^1.6",
         "drupal/devel": "^1.2",
-        "drupal/drupal-extension": "^4.0.0@alpha",
+        "drupal/drupal-extension": "~4.0",
         "drush/drush": "^9",
         "nikic/php-parser": "~3.0",
         "openeuropa/behat-transformation-context" : "~0.1",


### PR DESCRIPTION
After moving from drupal-extension v3 to v4 Drupal\MinkExtension has to be used.